### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/SproutEncodeEmail.php
+++ b/src/SproutEncodeEmail.php
@@ -34,6 +34,6 @@ class SproutEncodeEmail extends Plugin
 
         self::$app = $this->get('app');
 
-        Craft::$app->view->twig->addExtension(new TwigExtensions());
+            Craft::$app->view->registerTwigExtension(new TwigExtensions());
     }
 }


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.